### PR TITLE
Cleanup documentation

### DIFF
--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -94,7 +94,6 @@ all subtypes of [`TurbulenceCorrection`](@ref)
 ```@docs
 TI_Influence
 TI_None
-TI_wGaspariAndCohn
 ```
 
 ## Defining the controller

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -74,7 +74,6 @@ all subtypes of [`VelCorrection`](@ref)
 ```@docs
 Velocity_Influence
 Velocity_None
-Velocity_wGaspariAndCohn
 ```
 
 ## Defining the direction correction

--- a/src/FLORIDyn.jl
+++ b/src/FLORIDyn.jl
@@ -33,8 +33,8 @@ export WindVelType, WindVelMatrix, WindFarm
 export Floris, FloriDyn, Wind, Sim, Con, IterateOPsBuffers
 
 export Direction_All, Direction_Influence, Direction_None
-export Velocity_Influence, Velocity_None, Velocity_wGaspariAndCohn
-export TI_Influence, TI_None, TI_wGaspariAndCohn
+export Velocity_Influence, Velocity_None
+export TI_Influence, TI_None
 export IterateOPs_average, IterateOPs_basic, IterateOPs_buffer, IterateOPs_maximum, IterateOPs_weighted
 export Yaw_Constant, Yaw_InterpTurbine, Yaw_SOWFA
 

--- a/src/correction/structs_dir.jl
+++ b/src/correction/structs_dir.jl
@@ -24,6 +24,9 @@ struct Direction_All <: DirCorrection end
     Direction_Influence <: DirCorrection
 
 A marker struct used to represent direction correction based on influence modeling.
+
+# WARNING
+This correction type is **not yet implemented**!
 """
 struct Direction_Influence <: DirCorrection end
 
@@ -31,5 +34,8 @@ struct Direction_Influence <: DirCorrection end
     Direction_None <: DirCorrection
 
 A marker struct used to indicate that no direction corrections should be applied.
+
+# WARNING
+This correction type is **not yet implemented**!
 """
 struct Direction_None <: DirCorrection end

--- a/src/correction/structs_turb.jl
+++ b/src/correction/structs_turb.jl
@@ -17,6 +17,9 @@ abstract type TurbulenceCorrection end
     TI_Influence <: TurbulenceCorrection
 
 A marker struct used to represent turbulence intensity correction based on influence modeling.
+
+# WARNING
+This correction type is **not yet implemented**!
 """
 struct TI_Influence <: TurbulenceCorrection end
 
@@ -26,11 +29,3 @@ struct TI_Influence <: TurbulenceCorrection end
 A marker struct used to indicate that no turbulence intensity corrections should be applied.
 """
 struct TI_None <: TurbulenceCorrection end
-
-"""
-    TI_wGaspariAndCohn <: TurbulenceCorrection
-
-A marker struct used to represent turbulence intensity correction using the Gaspari and Cohn localization method.
-This correction method is commonly used in ensemble data assimilation for spatial localization.
-"""
-struct TI_wGaspariAndCohn <: TurbulenceCorrection end

--- a/src/correction/structs_vel.jl
+++ b/src/correction/structs_vel.jl
@@ -17,6 +17,9 @@ abstract type VelCorrection end
     Velocity_Influence <: VelCorrection
 
 A marker struct used to represent velocity correction based on influence modeling.
+
+# WARNING
+This correction type is **not yet implemented**!
 """
 struct Velocity_Influence <: VelCorrection end
 

--- a/src/correction/structs_vel.jl
+++ b/src/correction/structs_vel.jl
@@ -27,10 +27,3 @@ A marker struct used to indicate that no velocity corrections should be applied.
 """
 struct Velocity_None <: VelCorrection end
 
-"""
-    Velocity_wGaspariAndCohn <: VelCorrection
-
-A marker struct used to represent velocity correction using the Gaspari and Cohn localization method.
-This correction method is commonly used in ensemble data assimilation for spatial localization.
-"""
-struct Velocity_wGaspariAndCohn <: VelCorrection end

--- a/src/floridyn_cl/structs.jl
+++ b/src/floridyn_cl/structs.jl
@@ -63,6 +63,9 @@ the advancement step, resulting in more stable observation point trajectories.
 This model may require additional computational resources compared to basic 
 methods but provides better stability characteristics for challenging 
 simulation scenarios.
+
+# WARNING
+**Not yet implemented**
 """
 struct IterateOPs_average <: IterateOPs_model end
 
@@ -193,6 +196,9 @@ Particularly useful in:
 This model may produce more conservative results compared to other 
 iteration strategies and should be used when understanding bounds 
 on simulation behavior is important.
+
+# WARNING
+**Not yet implemented**
 """
 struct IterateOPs_maximum <: IterateOPs_model end
 
@@ -244,6 +250,9 @@ time, or other relevant metrics.
 This model provides the highest accuracy among available iteration 
 strategies but requires additional computational resources. Best suited 
 for applications where accuracy is prioritized over computational speed.
+
+# WARNING
+**Not yet implemented**
 """
 struct IterateOPs_weighted <: IterateOPs_model end
 

--- a/src/floridyn_cl/structs.jl
+++ b/src/floridyn_cl/structs.jl
@@ -29,6 +29,9 @@ approach to handling the temporal and spatial evolution of observation points.
 - [`IterateOPs_buffer`](@ref): Buffered approach for memory efficiency
 - [`IterateOPs_maximum`](@ref): Maximum value-based iteration
 - [`IterateOPs_weighted`](@ref): Weighted interpolation method
+
+# WARNING
+Currently, only [`IterateOPs_basic`](@ref) is fully implemented and tested.
 """
 abstract type IterateOPs_model end
 

--- a/src/windfield/structs_turb.jl
+++ b/src/windfield/structs_turb.jl
@@ -24,6 +24,9 @@ struct TI_Constant <: TurbulenceModel end
     TI_EnKF_InterpTurbine <: TurbulenceModel
 
 A marker struct representing the Turbulence Intensity (TI) Ensemble Kalman Filter (EnKF) interpolation model.
+
+# WARNING
+This model is **not yet implemented**!
 """
 struct TI_EnKF_InterpTurbine <: TurbulenceModel end
 

--- a/src/windfield/structs_vel.jl
+++ b/src/windfield/structs_vel.jl
@@ -78,6 +78,9 @@ at arbitrary spatial locations based on available measurement data or model pred
 
 # See also:
 - [`VelModel`](@ref): Abstract supertype for velocity models.
+
+# WARNING
+This model is **not yet implemented**!
 """
 struct Velocity_Interpolation <: VelModel end
 

--- a/src/windfield/structs_vel.jl
+++ b/src/windfield/structs_vel.jl
@@ -64,6 +64,9 @@ to estimate wind velocity fields, typically used for advanced wind field reconst
 
 # See also:
 - [`VelModel`](@ref): Abstract supertype for velocity models.
+
+# WARNING
+This model is **not yet implemented**!
 """
 struct Velocity_I_and_I <: VelModel end
 
@@ -78,9 +81,6 @@ at arbitrary spatial locations based on available measurement data or model pred
 
 # See also:
 - [`VelModel`](@ref): Abstract supertype for velocity models.
-
-# WARNING
-This model is **not yet implemented**!
 """
 struct Velocity_Interpolation <: VelModel end
 

--- a/src/windfield/structs_vel.jl
+++ b/src/windfield/structs_vel.jl
@@ -139,6 +139,9 @@ with both predictable trends and random fluctuations.
 
 # See also:
 - [`VelModel`](@ref): Abstract supertype for velocity models.
+
+# WARNING
+This model is **not yet implemented**!
 """
 struct Velocity_RW_with_Mean <: VelModel end
 


### PR DESCRIPTION
- [x] Remove references to wGaspariAndCohn (was never implemented)
- [x] Add warnings to the interateOPs methods that are not yet implemented
- [x] Add warnings to velocity and turbulence related marker structs that are not in use yet